### PR TITLE
Hydro or Indigo distribution now chosen based on the Ubuntu version. 

### DIFF
--- a/project2/run
+++ b/project2/run
@@ -1,6 +1,14 @@
 #!/bin/bash
 
-ROS_DISTRO=hydro
+ROS_DISTRO=
+UBUNTU_MAJOR_VERSION=`cat /etc/issue | cut -c 8-9`
+UBUNTU_MINOR_VERSION=`cat /etc/issue | cut -c 11-12`
+if [ "$UBUNTU_MAJOR_VERSION" -eq "12" ]
+then ROS_DISTRO=hydro
+elif [ "$UBUNTU_MAJOR_VERSION" -eq "13" -a "$UBUNTU_MINOR_VERSION" -eq "04" ]
+then ROS_DISTRO=hydro
+else ROS_DISTRO=indigo
+fi
 
 source /opt/ros/$ROS_DISTRO/setup.bash
 export ROS_PACKAGE_PATH=`pwd`:$ROS_PACKAGE_PATH


### PR DESCRIPTION
I added some code to the "run" file so that hydro will be chosen as the ros distro if Ubuntu is version 13.04 or lower. Indigo will be chosen if Ubuntu is version 13.10 or 14.04. (This has only been tested on versions 12.04 or 14.04).
